### PR TITLE
feat: scaffold podcast page

### DIFF
--- a/apps/web/app/podcast/audio-player.tsx
+++ b/apps/web/app/podcast/audio-player.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Card, Text } from '@thewolfbook/ui';
+
+interface AudioPlayerProps {
+  src?: string;
+  title?: string;
+}
+
+export default function AudioPlayer({ src, title }: AudioPlayerProps) {
+  if (!src) {
+    return (
+      <Card style={{ padding: '1rem' }}>
+        <Text>Select an episode to play</Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card style={{ padding: '1rem' }}>
+      {title && <Text style={{ marginBottom: '0.5rem' }}>{title}</Text>}
+      <audio controls src={src} style={{ width: '100%' }} />
+    </Card>
+  );
+}

--- a/apps/web/app/podcast/episode-list.tsx
+++ b/apps/web/app/podcast/episode-list.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Card, Heading, Text, Button } from '@thewolfbook/ui';
+
+export interface Episode {
+  id: number;
+  title: string;
+  description: string;
+  audioUrl: string;
+}
+
+interface EpisodeListProps {
+  episodes: Episode[];
+  onSelect?: (episode: Episode) => void;
+}
+
+export default function EpisodeList({ episodes, onSelect }: EpisodeListProps) {
+  return (
+    <div>
+      {episodes.map((ep) => (
+        <Card key={ep.id} style={{ marginBottom: '1rem', padding: '1rem' }}>
+          <Heading>{ep.title}</Heading>
+          <Text>{ep.description}</Text>
+          <Button onClick={() => onSelect?.(ep)}>Play</Button>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/podcast/page.tsx
+++ b/apps/web/app/podcast/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import { Container, Heading } from '@thewolfbook/ui';
+import EpisodeList, { Episode } from './episode-list';
+import AudioPlayer from './audio-player';
+
+const mockEpisodes: Episode[] = [
+  {
+    id: 1,
+    title: 'Episode 1',
+    description: 'The first episode of our podcast.',
+    audioUrl: '/audio/episode1.mp3',
+  },
+  {
+    id: 2,
+    title: 'Episode 2',
+    description: 'Another thrilling episode.',
+    audioUrl: '/audio/episode2.mp3',
+  },
+];
+
+export default function PodcastPage() {
+  const [current, setCurrent] = useState<Episode | null>(null);
+
+  return (
+    <Container style={{ display: 'grid', gap: '1rem' }}>
+      <Heading>Podcast</Heading>
+      <EpisodeList episodes={mockEpisodes} onSelect={setCurrent} />
+      <AudioPlayer src={current?.audioUrl} title={current?.title} />
+    </Container>
+  );
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@thewolfbook/ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const Container = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...props}>{children}</div>
+);
+
+export const Card = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...props}>{children}</div>
+);
+
+export const Heading = ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h2 {...props}>{children}</h2>
+);
+
+export const Text = ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p {...props}>{children}</p>
+);
+
+export const Button = ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+  <button {...props}>{children}</button>
+);


### PR DESCRIPTION
## Summary
- scaffold basic UI primitives package
- add podcast page with episode list and audio player

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6ce5ea44832b834a81cd2e3a7ca4