### PR TITLE
chore: set up CI workflow and status badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-typecheck:
+    name: lint-typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm typecheck
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # TheWolfBook
-an interactive book I am writing for my friend. 
+
+[![Build Status](https://github.com/OWNER/TheWolfBook/actions/workflows/ci.yml/badge.svg?job=build)](https://github.com/OWNER/TheWolfBook/actions/workflows/ci.yml)
+[![Lint & Typecheck](https://github.com/OWNER/TheWolfBook/actions/workflows/ci.yml/badge.svg?job=lint-typecheck)](https://github.com/OWNER/TheWolfBook/actions/workflows/ci.yml)
+
+an interactive book I am writing for my friend.


### PR DESCRIPTION
## Summary
- add CI workflow that installs dependencies and runs lint, typecheck and build
- show build and lint/typecheck badges in README

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689e6ce8c610832b8a3cc39d97093de9