### PR TITLE
feat: add MDX content loader

### DIFF
--- a/content/books/rabbits/intro.mdx
+++ b/content/books/rabbits/intro.mdx
@@ -1,0 +1,7 @@
+---
+title: Rabbits Intro
+---
+
+# Rabbits Intro
+
+Welcome to the rabbits book. This is the introduction.

--- a/content/books/wolves/chapter-1.mdx
+++ b/content/books/wolves/chapter-1.mdx
@@ -1,0 +1,7 @@
+---
+title: Wolves Chapter 1
+---
+
+# Wolves Chapter 1
+
+This is the first chapter of the wolves book.

--- a/content/books/wolves/chapter-2.mdx
+++ b/content/books/wolves/chapter-2.mdx
@@ -1,0 +1,7 @@
+---
+title: Wolves Chapter 2
+---
+
+# Wolves Chapter 2
+
+The adventure continues in the second chapter.

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,3 +1,30 @@
 # Content Package
 
-This package will contain content loaders and utilities for books, chapters, and other data used in the Millennium Wolves multiverse project.
+Utilities for loading book and chapter content stored as MDX files.
+
+MDX files are expected under `content/books/<book>/<chapter>.mdx` at the repository root.
+
+## API
+
+- `getBooks()` – list all book ids
+- `getChapters(bookId)` – list chapter ids for a book
+- `getChapter(bookId, chapterId)` – return `{ meta, content }` for a chapter
+
+Front matter in each MDX file is parsed as simple key/value pairs.
+
+## Example
+
+```js
+const { getBooks, getChapters, getChapter } = require('./index');
+
+console.log(getBooks());
+// ['wolves', 'rabbits']
+
+console.log(getChapters('wolves'));
+// ['chapter-1', 'chapter-2']
+
+console.log(getChapter('wolves', 'chapter-1'));
+// { meta: { title: 'Wolves Chapter 1' }, content: '# Wolves Chapter 1\n\nThis is the first chapter...' }
+```
+
+A small sample dataset is included in `content/books` for testing.

--- a/packages/content/index.js
+++ b/packages/content/index.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+const CONTENT_ROOT = path.join(__dirname, '..', '..', 'content', 'books');
+
+function getBooks() {
+  if (!fs.existsSync(CONTENT_ROOT)) return [];
+  return fs.readdirSync(CONTENT_ROOT, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+}
+
+function getChapters(bookId) {
+  const bookPath = path.join(CONTENT_ROOT, bookId);
+  if (!fs.existsSync(bookPath)) return [];
+  return fs.readdirSync(bookPath, { withFileTypes: true })
+    .filter((dirent) => dirent.isFile() && dirent.name.endsWith('.mdx'))
+    .map((dirent) => dirent.name.replace(/\.mdx$/, ''));
+}
+
+function parseFrontMatter(source) {
+  if (source.startsWith('---')) {
+    const end = source.indexOf('\n---', 3);
+    if (end !== -1) {
+      const raw = source.slice(3, end).trim();
+      const content = source.slice(end + 4).trim();
+      const meta = {};
+      raw.split('\n').forEach((line) => {
+        const idx = line.indexOf(':');
+        if (idx !== -1) {
+          const key = line.slice(0, idx).trim();
+          const value = line.slice(idx + 1).trim();
+          meta[key] = value;
+        }
+      });
+      return { meta, content };
+    }
+  }
+  return { meta: {}, content: source };
+}
+
+function getChapter(bookId, chapterId) {
+  const filePath = path.join(CONTENT_ROOT, bookId, `${chapterId}.mdx`);
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const source = fs.readFileSync(filePath, 'utf8');
+  const { meta, content } = parseFrontMatter(source);
+  return { meta, content };
+}
+
+module.exports = {
+  getBooks,
+  getChapters,
+  getChapter,
+};

--- a/packages/content/test.js
+++ b/packages/content/test.js
@@ -1,0 +1,5 @@
+const { getBooks, getChapters, getChapter } = require('./index');
+
+console.log('Books:', getBooks());
+console.log('Wolves chapters:', getChapters('wolves'));
+console.log('Chapter data:', getChapter('wolves', 'chapter-1'));


### PR DESCRIPTION
## Summary
- add utilities to load MDX books and chapters from filesystem
- document new content package and include sample dataset

## Testing
- `node packages/content/test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e6cdfb898832b8a90906248c3ec9b