### PR TITLE
feat(ui): add design tokens and primitives

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,3 +1,43 @@
-# UI Package
+# @thewolfbook/ui
 
-This package will house shared UI components and design tokens for the Millennium Wolves multiverse project.
+Shared design tokens and primitive components for the Millennium Wolves multiverse project.
+
+## Design Tokens
+
+```ts
+import { colors, spacing, radii } from '@thewolfbook/ui';
+```
+
+## Tailwind preset
+
+Extend your Tailwind config with the preset:
+
+```ts
+// tailwind.config.ts
+import preset from '@thewolfbook/ui/tailwind.config';
+
+export default {
+  presets: [preset],
+};
+```
+
+## Components
+
+```tsx
+import { Button, Card, CardHeader, CardTitle, CardContent, Text } from '@thewolfbook/ui';
+
+export function Example() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Welcome</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Text>
+          <Button>Click me</Button>
+        </Text>
+      </CardContent>
+    </Card>
+  );
+}
+```

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@thewolfbook/ui",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^2.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  }
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary' | 'destructive';
+  size?: 'default' | 'sm' | 'lg';
+}
+
+const buttonVariants: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default: 'bg-primary text-white hover:bg-primary/90',
+  secondary: 'bg-secondary text-white hover:bg-secondary/90',
+  destructive: 'bg-red-600 text-white hover:bg-red-600/90',
+};
+
+const sizeVariants: Record<NonNullable<ButtonProps['size']>, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 px-3',
+  lg: 'h-11 px-8',
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+          buttonVariants[variant],
+          sizeVariants[size],
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('rounded-lg border bg-background text-foreground shadow-sm', className)} {...props} />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardContent };

--- a/packages/ui/src/components/text.tsx
+++ b/packages/ui/src/components/text.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+export interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  variant?: 'p' | 'lead' | 'muted' | 'small';
+}
+
+const variants: Record<NonNullable<TextProps['variant']>, string> = {
+  p: 'text-base',
+  lead: 'text-xl text-muted',
+  muted: 'text-sm text-muted',
+  small: 'text-sm font-medium',
+};
+
+const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
+  ({ className, variant = 'p', ...props }, ref) => (
+    <p ref={ref} className={cn(variants[variant], className)} {...props} />
+  )
+);
+Text.displayName = 'Text';
+
+export { Text };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,4 @@
+export * from './tokens';
+export * from './components/button';
+export * from './components/card';
+export * from './components/text';

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,0 +1,29 @@
+export const colors = {
+  primary: '#1e40af',
+  secondary: '#9333ea',
+  accent: '#f59e0b',
+  muted: '#64748b',
+  background: '#ffffff',
+  foreground: '#000000',
+};
+
+export const spacing = {
+  0: '0px',
+  1: '0.25rem',
+  2: '0.5rem',
+  3: '0.75rem',
+  4: '1rem',
+  5: '1.25rem',
+  6: '1.5rem',
+  8: '2rem',
+  10: '2.5rem',
+  12: '3rem',
+};
+
+export const radii = {
+  none: '0px',
+  sm: '0.125rem',
+  md: '0.375rem',
+  lg: '0.5rem',
+  full: '9999px',
+};

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+import { colors, spacing, radii } from './src/tokens';
+
+const config: Config = {
+  content: [],
+  theme: {
+    extend: {
+      colors,
+      spacing,
+      borderRadius: radii,
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add color, spacing, and radius tokens
- export tailwind preset consuming the design tokens
- introduce shadcn-style Button, Card, and Text components with examples

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6cc2df70832ba838478f28f0fec3