### PR TITLE
feat: enable static export and dynamic chapter page

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,8 +28,14 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Static Build and Export
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+To build the static site for GitHub Pages, run:
+
+`pnpm --filter apps/web build`
+
+`pnpm --filter apps/web export`
+
+This creates an `out` directory under `apps/web` with the pre-rendered HTML for all pages. When the site is built in GitHub Actions, the `basePath` and `assetPrefix` are set to `/TheWolfBook`, so the static files work when hosted at `https://<username>.github.io/TheWolfBook/`.
+

--- a/apps/web/app/read/[book]/[chapter]/page.tsx
+++ b/apps/web/app/read/[book]/[chapter]/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const dynamic = 'force-static';
+
+export function generateStaticParams() {
+  return [
+    { book: 'book-1', chapter: '1' },
+  ];
+}
+
+interface ChapterPageProps {
+  params: { book: string; chapter: string };
+}
+
+export default function Page({ params }: ChapterPageProps) {
+  const { book, chapter } = params;
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Book {book} - Chapter {chapter}</h1>
+      <p>Content coming soon.</p>
+    </div>
+  );
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  images: { unoptimized: true },
+  basePath: process.env.GITHUB_ACTIONS ? '/TheWolfBook' : undefined,
+  assetPrefix: process.env.GITHUB_ACTIONS ? '/TheWolfBook/' : undefined,
+};
 
 export default nextConfig;


### PR DESCRIPTION
This PR configures the Next.js web app for static export and prepares dynamic chapter routes.

- Set `output: 'export'`, `trailingSlash: true`, and disabled image optimization in `next.config.mjs`.
- Added conditional `basePath` and `assetPrefix` for GitHub Pages when `GITHUB_ACTIONS` is set.
- Added a stub dynamic route at `app/read/[book]/[chapter]/page.tsx` with `generateStaticParams` returning one chapter (book-1/chapter-1).
- Updated `apps/web/README.md` with instructions for building and exporting the static site and explained basePath behavior.

After merging, the site can be built and exported with `pnpm --filter apps/web build` and `pnpm --filter apps/web export`, producing the static `out` directory for deployment.